### PR TITLE
change in maths accelerator md

### DIFF
--- a/doc/accelerator-guide.md
+++ b/doc/accelerator-guide.md
@@ -182,8 +182,8 @@ To summarise the `ready` and `valid` signals:
    1. Start Vivado 2023.2
    2. Go to Window→TCL Console
    3. In the console, type `cd <repository path>/maths-accelerator/overlay`. You will need to use a Unix-style path with `/` instead of `\`
-   4. Enter the command `./source build_ip.tcl`
-   4. Enter the command `./source base.tcl`
+   4. Enter the command `source build_ip.tcl`
+   4. Enter the command `source base.tcl`
 4. The scripts compile some IP blocks and generate a Vivado project in \<repository path\>/maths-accelerator/overlay/base. Open it in Vivado
 5. Generate the block design with IP Integrator. This converts the block design to Verilog netlists and creates the hardware handoff file `.hwh` with information about the bus structure and address map for the operating system.
 


### PR DESCRIPTION
in maths accelerator, the command `./source build_ip.tcl` and `./source base.tcl` should get rid of `./`